### PR TITLE
Add WCAG contrast level checker

### DIFF
--- a/Pixel Picker.xcodeproj/project.pbxproj
+++ b/Pixel Picker.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		BAA17B7C20B14CEB00625455 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAA17B7B20B14CEB00625455 /* SwiftyJSON.framework */; };
 		BAA17B7D20B14CEB00625455 /* SwiftyJSON.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BAA17B7B20B14CEB00625455 /* SwiftyJSON.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BAB6F14F221ABB3500EA11D4 /* ShowAndHideCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB6F14E221ABB3500EA11D4 /* ShowAndHideCursor.swift */; };
+		D62EACF22465996700686344 /* WCAG.swift in Sources */ = {isa = PBXBuildFile; fileRef = D62EACF12465996700686344 /* WCAG.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +103,7 @@
 		BAA17B7220B14CC100625455 /* MASShortcut.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MASShortcut.framework; path = Carthage/Build/Mac/MASShortcut.framework; sourceTree = "<group>"; };
 		BAA17B7B20B14CEB00625455 /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/Mac/SwiftyJSON.framework; sourceTree = "<group>"; };
 		BAB6F14E221ABB3500EA11D4 /* ShowAndHideCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAndHideCursor.swift; sourceTree = "<group>"; };
+		D62EACF12465996700686344 /* WCAG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCAG.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,6 +193,7 @@
 				15349DB720BAE3F70071CAA1 /* NSBezierPath.swift */,
 				BA74C14120AA409D00306B27 /* NSColor.swift */,
 				15492102207B53AE00E45BBC /* Util.swift */,
+				D62EACF12465996700686344 /* WCAG.swift */,
 				B3B4C2C21E25894B009F8E4E /* Assets.xcassets */,
 				BA22232A20B0E3B50001069C /* README.md */,
 				155D2C02204F61220087478B /* Credits.rtfd */,
@@ -349,6 +352,7 @@
 				BA22232920B04D660001069C /* AppDelegate+Menu.swift in Sources */,
 				BA74C14E20ADA33E00306B27 /* PPColor.swift in Sources */,
 				15FC8CC8204E2E2C000B5E1E /* PPState.swift in Sources */,
+				D62EACF22465996700686344 /* WCAG.swift in Sources */,
 				BA74C13120A6E95900306B27 /* PPOverlayPanel.swift in Sources */,
 				BA74C14020AA390400306B27 /* PPOverlayPreview.swift in Sources */,
 				BA74C14420AA609500306B27 /* PPOverlayWrapper.swift in Sources */,

--- a/Pixel Picker/AppDelegate+Menu.swift
+++ b/Pixel Picker/AppDelegate+Menu.swift
@@ -99,6 +99,7 @@ extension AppDelegate: NSMenuDelegate {
         buildShortcutMenuItem()
         buildUseUppercaseItem()
         buildLaunchAtLoginItem()
+        buildShowWCAGItem()
 
         contextMenu.addItem(.separator())
         contextMenu.addItem(withTitle: "About", action: #selector(showAboutPanel), keyEquivalent: "")
@@ -200,6 +201,15 @@ extension AppDelegate: NSMenuDelegate {
     private func buildLaunchAtLoginItem() {
         let item = contextMenu.addItem(withTitle: "Launch \(APP_NAME) at Login", action: #selector(launchAtLogin(_:)), keyEquivalent: "")
         item.state = LaunchAtLogin.isEnabled ? .on : .off
+    }
+    
+    private func buildShowWCAGItem() {
+        let item = contextMenu.addItem(withTitle: "Show WCAG contrast level", action: #selector(setShowWCAG(_:)), keyEquivalent: "")
+        item.state = PPState.shared.showWCAGLevel ? .on : .off
+    }
+    
+    @objc private func setShowWCAG(_ sender: NSMenuItem) {
+        PPState.shared.showWCAGLevel = sender.state != .on
     }
 
     @objc private func launchAtLogin(_ sender: NSMenuItem) {

--- a/Pixel Picker/NSColor.swift
+++ b/Pixel Picker/NSColor.swift
@@ -50,4 +50,31 @@ extension NSColor {
         let L = 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
         return L > 0.197 ? NSColor.black : NSColor.white
     }
+    
+    // Calculates the contrast ratio of this color and another one, according to the W3C "Web Content Accessibility Guidelines (WCAG) 2.0" Recommendation (https://www.w3.org/TR/WCAG20/).
+    // Adopted from: https://gist.github.com/ngquerol/23d6d5ebd051e18682badafa37e48442
+    public func contrastRatio(to color: NSColor) -> CGFloat {
+        let luminance1 = relativeLuminance,
+            luminance2 = color.relativeLuminance
+
+        if luminance1 < luminance2 {
+            return (luminance2 + 0.05) / (luminance1 + 0.05)
+        } else {
+            return (luminance1 + 0.05) / (luminance2 + 0.05)
+        }
+    }
+    
+    // Calculates the relative brightness of a color, according to the W3C "Web Content Accessibility Guidelines (WCAG) 2.0" Recommendation (https://www.w3.org/TR/WCAG20/).
+    // Adopted from: https://gist.github.com/ngquerol/23d6d5ebd051e18682badafa37e48442
+    public var relativeLuminance: CGFloat {
+        let f = { (component: CGFloat) -> CGFloat in
+            return component <= 0.03928 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4)
+        }
+        
+        let red = f(redComponent)
+        let green = f(greenComponent)
+        let blue = f(blueComponent)
+
+        return red * 0.2126 + green * 0.7152 + blue * 0.0722
+    }
 }

--- a/Pixel Picker/OverlayPanel/PPOverlayController.swift
+++ b/Pixel Picker/OverlayPanel/PPOverlayController.swift
@@ -18,6 +18,8 @@ class PPOverlayController: NSWindowController {
     @IBOutlet weak var infoWrapper: NSView!
     @IBOutlet weak var infoFormatField: NSTextField!
     @IBOutlet weak var infoDetailField: NSTextField!
+    @IBOutlet weak var infoContrastView: NSView!
+    @IBOutlet weak var infoContrastField: NSTextField!
 
     // This mode increases the picker's size, increases the magnification and also slows down move
     // events to make it easier to pick the right pixel. We dissociate the mouse (input) from the
@@ -66,6 +68,8 @@ class PPOverlayController: NSWindowController {
         infoWrapper.wantsLayer = true
         infoWrapper.layer?.cornerRadius = 8
         infoWrapper.layer?.backgroundColor = NSColor.black.cgColor
+        infoContrastView.wantsLayer = true
+        infoContrastView.layer?.cornerRadius = 3
 
         // For some reason if we don't listen for events this way we miss the escape key.
         NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) {
@@ -274,6 +278,19 @@ class PPOverlayController: NSWindowController {
         infoDetailField.textColor = contrastingColor
         infoFormatField.stringValue = PPState.shared.chosenFormat.rawValue
         infoDetailField.stringValue = PPState.shared.chosenFormat.asComponentString(withColor: color)
+        
+        if let previousPick = PPState.shared.recentPicks.last, PPState.shared.showWCAGLevel {
+            infoContrastView.isHidden = false
+            
+            let wcagLevel = WCAGLevel(contrastRatio: color.contrastRatio(to: previousPick.color))
+            infoContrastField.stringValue = wcagLevel.rawValue
+            
+            infoContrastView.layer?.backgroundColor = previousPick.color.cgColor
+            infoContrastField.textColor = previousPick.color.bestContrastingColor()
+        } else {
+            infoContrastView.isHidden = true
+        }
+        
         resizeInfoPanel()
     }
 

--- a/Pixel Picker/OverlayPanel/PPOverlayController.swift
+++ b/Pixel Picker/OverlayPanel/PPOverlayController.swift
@@ -279,9 +279,11 @@ class PPOverlayController: NSWindowController {
         infoFormatField.stringValue = PPState.shared.chosenFormat.rawValue
         infoDetailField.stringValue = PPState.shared.chosenFormat.asComponentString(withColor: color)
         
+        // Show contrast level if it's enabled and a color has previously been picked.
         if let previousPick = PPState.shared.recentPicks.last, PPState.shared.showWCAGLevel {
             infoContrastView.isHidden = false
             
+            // Calculate constrast ratio between current and previously picked color.
             let wcagLevel = WCAGLevel(contrastRatio: color.contrastRatio(to: previousPick.color))
             infoContrastField.stringValue = wcagLevel.rawValue
             

--- a/Pixel Picker/OverlayPanel/PPOverlayController.xib
+++ b/Pixel Picker/OverlayPanel/PPOverlayController.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14109"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,6 +19,8 @@
         </customObject>
         <customObject id="ECQ-9M-Pkg" customClass="PPOverlayController" customModule="PixelPicker" customModuleProvider="target">
             <connections>
+                <outlet property="infoContrastField" destination="iRx-oZ-llC" id="gxr-6f-BkE"/>
+                <outlet property="infoContrastView" destination="dIL-Oc-RkF" id="8ya-Ai-pt6"/>
                 <outlet property="infoDetailField" destination="Re2-GH-fyd" id="K03-75-cf9"/>
                 <outlet property="infoFormatField" destination="1fa-UE-yMM" id="Nan-fO-kbu"/>
                 <outlet property="infoPanel" destination="OMO-LB-w57" id="GGj-Y6-LfU"/>
@@ -30,11 +31,11 @@
                 <outlet property="wrapper" destination="acW-WA-gq2" id="Mpu-0H-rtC"/>
             </connections>
         </customObject>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="gZA-A3-IZ5" customClass="PPOverlayPanel" customModule="PixelPicker" customModuleProvider="target">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="gZA-A3-IZ5" customClass="PPOverlayPanel" customModule="PixelPicker" customModuleProvider="target">
             <windowStyleMask key="styleMask" utility="YES" nonactivatingPanel="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="132" width="101" height="101"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="acW-WA-gq2" customClass="PPOverlayWrapper" customModule="PixelPicker" customModuleProvider="target">
                 <rect key="frame" x="0.0" y="0.0" width="101" height="101"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -52,38 +53,70 @@
             </view>
             <point key="canvasLocation" x="236" y="82"/>
         </window>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="OMO-LB-w57" customClass="PPOverlayPanel" customModule="PixelPicker" customModuleProvider="target">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="OMO-LB-w57" customClass="PPOverlayPanel" customModule="PixelPicker" customModuleProvider="target">
             <windowStyleMask key="styleMask" utility="YES" nonactivatingPanel="YES"/>
             <rect key="contentRect" x="926" y="538" width="100" height="50"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
-            <view key="contentView" id="HED-rR-FDP">
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <view key="contentView" misplaced="YES" id="HED-rR-FDP">
                 <rect key="frame" x="0.0" y="0.0" width="100" height="50"/>
-                <autoresizingMask key="autoresizingMask"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1fa-UE-yMM">
-                        <rect key="frame" x="-2" y="25" width="104" height="17"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="RkG-Wy-Shq">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Re2-GH-fyd">
-                        <rect key="frame" x="-2" y="8" width="104" height="14"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="IYd-1Y-7cd">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
+                    <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GvI-6B-Cz3">
+                        <rect key="frame" x="0.0" y="8" width="163" height="56"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1fa-UE-yMM">
+                                <rect key="frame" x="61" y="40" width="41" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="RkG-Wy-Shq">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Re2-GH-fyd">
+                                <rect key="frame" x="63" y="22" width="37" height="14"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="IYd-1Y-7cd">
+                                    <font key="font" metaFont="label" size="11"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="dIL-Oc-RkF">
+                                <rect key="frame" x="0.0" y="0.0" width="163" height="18"/>
+                                <subviews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="iRx-oZ-llC">
+                                        <rect key="frame" x="2" y="2" width="159" height="14"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="WGV-Vi-VsP">
+                                            <font key="font" metaFont="label" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="iRx-oZ-llC" secondAttribute="trailing" constant="4" id="N7S-Bx-3p1"/>
+                                    <constraint firstAttribute="bottom" secondItem="iRx-oZ-llC" secondAttribute="bottom" constant="2" id="cN6-Qx-Meg"/>
+                                    <constraint firstItem="iRx-oZ-llC" firstAttribute="leading" secondItem="dIL-Oc-RkF" secondAttribute="leading" constant="4" id="pS4-Xb-76o"/>
+                                    <constraint firstItem="iRx-oZ-llC" firstAttribute="top" secondItem="dIL-Oc-RkF" secondAttribute="top" constant="2" id="xNR-KQ-YT8"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <visibilityPriorities>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                            <integer value="1000"/>
+                        </visibilityPriorities>
+                        <customSpacing>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                            <real value="3.4028234663852886e+38"/>
+                        </customSpacing>
+                    </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="1fa-UE-yMM" firstAttribute="leading" secondItem="HED-rR-FDP" secondAttribute="leading" id="23z-pW-nAx"/>
-                    <constraint firstItem="1fa-UE-yMM" firstAttribute="top" secondItem="HED-rR-FDP" secondAttribute="top" constant="8" id="G1j-j5-iWY"/>
-                    <constraint firstItem="Re2-GH-fyd" firstAttribute="leading" secondItem="HED-rR-FDP" secondAttribute="leading" id="aZf-QY-Lpd"/>
-                    <constraint firstAttribute="bottom" secondItem="Re2-GH-fyd" secondAttribute="bottom" constant="8" id="amm-jV-oWa"/>
-                    <constraint firstAttribute="trailing" secondItem="1fa-UE-yMM" secondAttribute="trailing" id="flM-Te-2qj"/>
-                    <constraint firstAttribute="trailing" secondItem="Re2-GH-fyd" secondAttribute="trailing" id="jWO-5f-uxW"/>
+                    <constraint firstItem="GvI-6B-Cz3" firstAttribute="leading" secondItem="HED-rR-FDP" secondAttribute="leading" id="3zK-14-Xf5"/>
+                    <constraint firstAttribute="bottom" secondItem="GvI-6B-Cz3" secondAttribute="bottom" constant="8" id="apf-V6-NGV"/>
+                    <constraint firstItem="GvI-6B-Cz3" firstAttribute="top" secondItem="HED-rR-FDP" secondAttribute="top" constant="8" id="dK9-Wq-zGV"/>
+                    <constraint firstAttribute="trailing" secondItem="GvI-6B-Cz3" secondAttribute="trailing" id="mj1-AT-sJL"/>
                 </constraints>
             </view>
             <point key="canvasLocation" x="236" y="230"/>

--- a/Pixel Picker/PPState.swift
+++ b/Pixel Picker/PPState.swift
@@ -29,6 +29,9 @@ import CleanroomLogger
     // Whether the color format should be uppercased or not.
     var useUppercase: Bool = false
     
+    // Whether to display the WCAG contrast level when picking a color.
+    var showWCAGLevel: Bool = false
+    
     // The chosen icon for the status item (the icon in the menu bar).
     var statusItemImageName: String = "icon-default"
 
@@ -84,6 +87,7 @@ import CleanroomLogger
     func resetState() {
         paschaModeEnabled = false
         useUppercase = false
+        showWCAGLevel = false
         statusItemImageName = "icon-default"
         focusModeModifier = .control
         activatingShortcut = nil
@@ -118,6 +122,8 @@ import CleanroomLogger
                     paschaModeEnabled = value.bool ?? false
                 case "useUppercase":
                     useUppercase = value.bool ?? false
+                case "showWCAGLevel":
+                    showWCAGLevel = value.bool ?? false
                 case "statusItemImageName":
                     statusItemImageName = value.string ?? "icon-default"
                 case "focusModeModifier":
@@ -175,6 +181,7 @@ import CleanroomLogger
         let json: JSON = [
             "paschaModeEnabled": paschaModeEnabled,
             "useUppercase": useUppercase,
+            "showWCAGLevel": showWCAGLevel,
             "statusItemImageName": statusItemImageName,
             "focusModeModifier": focusModeModifier.rawValue,
             "activatingShortcut": shortcutData,

--- a/Pixel Picker/WCAG.swift
+++ b/Pixel Picker/WCAG.swift
@@ -1,0 +1,28 @@
+//
+//  WCAG.swift
+//  Pixel Picker
+//
+
+import Foundation
+
+// Represents the different WCAG contrast levels defined by: https://www.w3.org/TR/WCAG20/.
+enum WCAGLevel: String {
+    case AAA
+    case AA
+    case OK
+    case Fail
+    
+    // The contrast intervals are based on the minimums for regular text in https://www.w3.org/TR/WCAG20/.
+    init(contrastRatio: CGFloat) {
+        switch contrastRatio {
+        case _ where contrastRatio >= 7:
+            self = .AAA
+        case _ where contrastRatio >= 4.5:
+            self = .AA
+        case _ where contrastRatio >= 3:
+            self = .OK
+        default:
+            self = .Fail
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pixel Picker is like Digital Color Meter, but lives in your menu bar and lets yo
 * 🎨 Supports different color spaces
 * ⌨️ Global keyboard shortcut activation
 * 🌄 Customisable preview
+* 🌓 WCAG contrast level checker
 * ✨
 
 ![demo of pixel-picker](./Resources/demo.png)
@@ -63,6 +64,8 @@ Pixel Picker provides some neat options:
     * The global keyboard shortcut to use that will activate Pixel Picker.
 * 🚀 **Launch at Login**
     * If this is enabled then Pixel Picker will be launched when you log into your computer.
+* 🌓 **WCAG Constrast Level**
+    * If enabled, will compare the current and last picked color and show the [WCAG constrast level](https://www.w3.org/TR/WCAG20/): Fail, OK, AA, or AAA.
 
 #### Extra Overrides or Hidden Settings
 


### PR DESCRIPTION
This PR adds a new feature allowing users to check the WCAG contrast level (https://www.w3.org/TR/WCAG20/) between two picked colours. When picking a colour, a new label will appear indicating the contrast level compared against the previously picked colour. The background of the label will also match the previous colour, providing for a nice side-by-side visualization.

There are four possible levels: AAA, AA, OK, and Fail. WCAG doesn't define a contrast ratio for level A and hence I opted to call it OK instead.

Here's what the feature looks like in action, comparing the heading colour to the background:

<img width="594" alt="wcag_example" src="https://user-images.githubusercontent.com/4345277/83945172-34122d80-a809-11ea-966f-c03170dbba1e.png">

The feature is disabled by default and can be enabled with a toggle in the menu. 

## Remaining work

I have yet to add any information to the README as I thought I would check in with you first. Would you like the feature to be mentioned in the README? If so, what emoji would you find fitting? I personally like 🌓!
